### PR TITLE
add catkin_package to enable ${CATKIN_PACKAGE_SHARE_DESTINATION}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(dynamixel_urdf)
 
 find_package(catkin REQUIRED)
 
+catkin_package()
+
 install(DIRECTORY meshes
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
otherwise we'll have

```

[dynamixel_urdf] ==> '/home/k-okada/catkin_ws/ws_enshu/build/dynamixel_urdf/build_env.sh /usr/bin/cmake /home/k-okada/catkin_ws/ws_enshu/src/robot-programming/dynamixel_urdf -DCATKIN_DEVEL_PREFIX=/home/k-okada/catkin_ws/ws_enshu/devel -DCMAKE_INSTALL_PREFIX=/home/k-okada/catkin_ws/ws_enshu/install' in '/home/k-okada/catkin_ws/ws_enshu/build/dynamixel_urdf'
-- Using CATKIN_DEVEL_PREFIX: /home/k-okada/catkin_ws/ws_enshu/devel
-- Using CMAKE_PREFIX_PATH: /home/k-okada/catkin_ws/ws_enshu/devel;/home/k-okada/catkin_ws/ws_denso/devel;/opt/ros/indigo
-- This workspace overlays: /home/k-okada/catkin_ws/ws_enshu/devel;/home/k-okada/catkin_ws/ws_denso/devel;/opt/ros/indigo
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/k-okada/catkin_ws/ws_enshu/build/dynamixel_urdf/test_results
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.6.15
CMake Error at CMakeLists.txt:6 (install):
  install DIRECTORY given no DESTINATION!


CMake Error at CMakeLists.txt:9 (install):
  install DIRECTORY given no DESTINATION!


```
